### PR TITLE
feat(run): support host bind mounts (type=host)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ docker run -d --name oneoff-docker-runner \
 ```
 
 This starts:
-- **REST API** (main.py): `http://localhost:8000` - `/run`,      `/volume`,      `/health`,      `/docs`
+- **REST API** (main.py): `http://localhost:8000` - `/run`,        `/volume`,        `/health`,        `/docs`
 - **MCP Server** (mcp.py): `http://localhost:8001` - `/mcp` (Streamable HTTP)
 
 ### REST API Usage
@@ -238,7 +238,7 @@ All parameters conform to the Pydantic schemas in `main.py` ( `RunContainerReque
 | volumes | object<string, VolumeConfig> | No | null | Mount settings. Keys are container-side paths (optional suffix `:ro` / `:rw` , default `rw` ) |
 
 Notes for volumes key:
-- Key format: `<container_path>[:ro|:rw]`, e.g.,   `/app/data`,   `/etc/config:ro`
+- Key format: `<container_path>[:ro|:rw]`, e.g.,     `/app/data`,     `/etc/config:ro`
 - Bind source is:
   - a temporary host directory/file expanded from `content` for `type=file|directory`
   - an existing Docker volume name when `type=volume`
@@ -262,10 +262,10 @@ Notes for volumes key:
 | response | boolean | No | false | file, directory | Whether to return the mounted content in the API response after execution |
 | mode | string (e.g. "0644") | No | null | file | File permission for the created file |
 | name | string | Conditionally | null | volume | Existing Docker volume name (required when `type=volume` ) |
-| host_path | string | Conditionally | null | host | Absolute host path to bind mount (required when `type=host`) |
+| host_path | string | Conditionally | null | host | Absolute host path to bind mount (required when `type=host` ) |
 
 Directory content format:
-- For `directory`,  `content` must be a base64 of a `tar.gz` archive created from the target directory (e.g.,   `tar czf dir.tar.gz dir && base64 < dir.tar.gz`).
+- For `directory`,  `content` must be a base64 of a `tar.gz` archive created from the target directory (e.g.,     `tar czf dir.tar.gz dir && base64 < dir.tar.gz`).
 
 #### Request Example
 
@@ -305,7 +305,7 @@ Directory content format:
 Notes:
 - When `pull_policy` is `always`, the image is pulled and `auth_config` is used if provided.
 - For `type=volume` with `response: true`, the content is not returned in the response (current behavior).
-- For `type=host`, `response` is not supported and will be rejected.
+- For `type=host`,  `response` is not supported and will be rejected.
 
 #### Host bind example
 
@@ -677,7 +677,7 @@ The dual-server architecture provides:
 
 - **REST API Server** (port 8000): Traditional HTTP REST API for direct integration
   - FastAPI with automatic OpenAPI documentation at `/docs`
-  - Endpoints: `/run`,      `/volume`,      `/health`
+  - Endpoints: `/run`,        `/volume`,        `/health`
   - Direct Docker container execution
   
 - **MCP Server** (port 8001): Model Context Protocol for AI agent integration

--- a/tests/test_run_container.py
+++ b/tests/test_run_container.py
@@ -77,3 +77,88 @@ def test_run_container(_mock_get_client):
     assert "stderr" in response_data["stderr"]
     assert "/app/data" in response_data["volumes"]
     assert response_data["volumes"]["/app/data"]["type"] == "directory"
+
+
+@patch("main.get_docker_client", side_effect=_dummy_client)
+def test_run_container_host_bind_file(_mock_get_client, tmp_path):
+    # Create a real temporary file on host
+    host_file = tmp_path / "host.txt"
+    host_file.write_text("from host\n")
+
+    request_payload = {
+        "image": "alpine:latest",
+        "command": ["sh", "-c", "cat /app/host.txt || true"],
+        "volumes": {
+            "/app/host.txt:ro": {
+                "type": "host",
+                "host_path": str(host_file),
+            }
+        },
+    }
+
+    response = client.post("/run", json=request_payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+
+
+@patch("main.get_docker_client", side_effect=_dummy_client)
+def test_run_container_host_bind_dir(_mock_get_client, tmp_path):
+    # Create a real temporary directory on host
+    host_dir = tmp_path / "data"
+    host_dir.mkdir()
+    (host_dir / "a.txt").write_text("A\n")
+
+    request_payload = {
+        "image": "alpine:latest",
+        "command": ["sh", "-c", "ls -la /app/data || true"],
+        "volumes": {
+            "/app/data": {
+                "type": "host",
+                "host_path": str(host_dir),
+            }
+        },
+    }
+
+    response = client.post("/run", json=request_payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+
+
+@patch("main.get_docker_client", side_effect=_dummy_client)
+def test_run_container_host_bind_requires_absolute(_mock_get_client):
+    request_payload = {
+        "image": "alpine:latest",
+        "command": ["sh", "-c", "true"],
+        "volumes": {
+            "/app/host.txt": {
+                "type": "host",
+                "host_path": "relative/path.txt",
+            }
+        },
+    }
+
+    response = client.post("/run", json=request_payload)
+    assert response.status_code == 400
+
+
+@patch("main.get_docker_client", side_effect=_dummy_client)
+def test_run_container_host_bind_response_not_allowed(_mock_get_client, tmp_path):
+    host_file = tmp_path / "host.txt"
+    host_file.write_text("x\n")
+
+    request_payload = {
+        "image": "alpine:latest",
+        "command": ["sh", "-c", "true"],
+        "volumes": {
+            "/app/host.txt": {
+                "type": "host",
+                "host_path": str(host_file),
+                "response": True,
+            }
+        },
+    }
+
+    response = client.post("/run", json=request_payload)
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary

Add host bind mount support to `/run` via `type: "host"` with `host_path` (absolute host path). This enables binding existing host files and directories into the container.

## Changes

- `main.py`
  - Extend `VolumeConfig` with `type="host"` and `host_path`.
  - Implement validation for `type=host` in `prepare_volumes`:
    - `host_path` is required
    - Must be an absolute path (validated with `realpath`)
    - Must exist on the host
    - `response` is not supported for `type=host` (returns 400)
  - Propagate `HTTPException` directly in `/run` (avoid over-catching).
- `tests/test_run_container.py`
  - Add success cases for binding host file and directory.
  - Add error cases for relative path and disallowed `response`.
- `README.md`
  - Document `type=host`, `host_path`, and include usage examples.

## API Additions

- `VolumeConfig.type`: `"file" | "directory" | "volume" | "host"`
- `VolumeConfig.host_path`: `string` (required for `type=host`, absolute path only)
- `type=host`: `response` is not supported and will be rejected.

### Minimal request example

```json
{
  "image": "alpine:latest",
  "command": ["sh", "-c", "ls -la /app && cat /app/host.txt || true"],
  "volumes": {
    "/app/host.txt:ro": { "type": "host", "host_path": "/absolute/path/to/host.txt" },
    "/app/data": { "type": "host", "host_path": "/absolute/path/to/dir" }
  }
}
```

## Compatibility

- No breaking changes to existing requests; default behavior remains unchanged.

## Tests

- `make format lint test` passes: 9 tests passed.


